### PR TITLE
Optional error throwing

### DIFF
--- a/lib/xml-mapping.js
+++ b/lib/xml-mapping.js
@@ -1,7 +1,8 @@
 var XMLWriter = require('xml-writer');
 var default_tag_name = 'row';
 
-exports.dump = function(obj) {
+exports.dump = function(obj, options) {
+  options = options || {};
 
 	if (typeof obj != "object") return obj;
 	//    if (typeof xw != XMLWriter) 
@@ -94,8 +95,14 @@ exports.dump = function(obj) {
 	return xw.toString();
 
 };
-exports.load = function(str) {
-	if (typeof str != "string") return str;
+exports.load = function(str, options) {
+	options = options || {};
+	if (typeof str != "string") {
+    if (options.throwErrors) {
+      throw new Error("Input was "+(typeof str)+", expected a string");
+    }
+    return str;
+  }
 
 	var parser = require("sax").parser(true, {trim:true, xmlns:false});
 	var result = {}, 
@@ -135,6 +142,11 @@ exports.load = function(str) {
 	}
 
 
+	if (!options.throwErrors) {
+		parser.onerror = function (e) {
+			// an error happened.
+		};
+  }
 	parser.onprocessinginstruction = function (pi) {
 	};
 	parser.ontext = function (v) {
@@ -171,19 +183,30 @@ exports.load = function(str) {
 	parser.onend = function () {
 	};
 
-	stack.push(result);
-	parser.write(str);
-	var line = parser.line;
-	var column = parser.column;
-	parser.close();
-	stack.pop();
-	
-	if (stack.length !== 0) {
-		var er = "Unexpected end of input";
-		er += "\nLine: "+line+
-			"\nColumn: "+column+
-			"\nChar: null";
-		throw new Error(er);
+	if (options.throwErrors) {
+		stack.push(result);
+		parser.write(str);
+		var line = parser.line;
+		var column = parser.column;
+		parser.close();
+		stack.pop();
+
+		if (stack.length !== 0) {
+			var er = "Unexpected end of input";
+			er += "\nLine: "+line+
+				"\nColumn: "+column+
+				"\nChar: null";
+			throw new Error(er);
+		}
+	} else {
+		stack.push(result);
+		try {
+			parser.write(str).close();
+		}
+		catch(e) {
+			return str;
+		}
+		stack.pop();
 	}
 	
 	return result;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "xml-mapping",
-    "version": "1.0.3",
+    "version": "1.1.0",
     "author": "Nicolas Thouvenin <nthouvenin@gmail.com>",
     "contributors": [],
     "description": "provide a bidirectionnal mapping between XML and JS data Structure (aka JSON)",

--- a/test/tojson.js
+++ b/test/tojson.js
@@ -85,10 +85,64 @@ exports['t04'] = function (test) {
 	test.done();
 };
 exports['t05'] = function (test) {
-	input = '<key1><key2>value1</key2><key3>value2</key3></key1>';
-	test.deepEqual(XMLMapping.load(input), { key1 : {  key2 : { $t : 'value1'}, key3 : { $t : 'value2'} } }); 
-	input = '<key1 key2="value1"><key3>value2</key3><key4>value3</key4></key1>';
-	test.deepEqual(XMLMapping.load(input), { key1 : { key2 : 'value1', key3 : { $t : 'value2'} , key4 : { $t : 'value3'} } }); 
-	test.done();
+  input = '<key1><key2>value1</key2><key3>value2</key3></key1>';
+  test.deepEqual(XMLMapping.load(input), { key1 : {  key2 : { $t : 'value1'}, key3 : { $t : 'value2'} } });
+  input = '<key1 key2="value1"><key3>value2</key3><key4>value3</key4></key1>';
+  test.deepEqual(XMLMapping.load(input), { key1 : { key2 : 'value1', key3 : { $t : 'value2'} , key4 : { $t : 'value3'} } });
+  test.done();
+};
+
+exports['t06a'] = function (test) {
+  input = {};
+  var caughtError = false;
+  try {
+    XMLMapping.load(input);
+  } catch (err) {
+    caughtError = true;
+  }
+  test.equal(caughtError, false);
+  try {
+    XMLMapping.load(input, {throwErrors: true});
+  } catch (err) {
+    caughtError = true;
+  }
+  test.equal(caughtError, true);
+  test.done();
+};
+
+exports['t06b'] = function (test) {
+  input = '<key1><key2>value1</key2><key3>value2</key3><partialTag';
+  var caughtError = false;
+  try {
+    XMLMapping.load(input);
+  } catch (err) {
+    caughtError = true;
+  }
+  test.equal(caughtError, false);
+  try {
+    XMLMapping.load(input, {throwErrors: true});
+  } catch (err) {
+    caughtError = true;
+  }
+  test.equal(caughtError, true);
+  test.done();
+};
+
+exports['t06c'] = function (test) {
+  input = '<key1><key2>value1</key2><key3>value2</key3>';
+  var caughtError = false;
+  try {
+    XMLMapping.load(input);
+  } catch (err) {
+    caughtError = true;
+  }
+  test.equal(caughtError, false);
+  try {
+    XMLMapping.load(input, {throwErrors: true});
+  } catch (err) {
+    caughtError = true;
+  }
+  test.equal(caughtError, true);
+  test.done();
 };
 /* */


### PR DESCRIPTION
The changes allow an optional options object to be passed in to calls to dump() or load().  The only supported option currently is load(xml, {throwErrors: true}) -- this will result in the following behavior changes:
- non-string input will cause a thrown exception
- parser errors will be thrown instead of caught
- a non-empty stack at the end of parsing will throw an error

Also included in this pull request are tests for those behaviors are present and a minor revision number bump to indicate the new feature.
