### PR TITLE
Fixed attribute handling during parse.

### DIFF
--- a/lib/xml-mapping.js
+++ b/lib/xml-mapping.js
@@ -34,16 +34,16 @@ exports.dump = function(obj, options) {
 			}
 		}
 		function keyComparator(a, b) {
-  		var a0 = a.charAt(0);
-  		var b0 = b.charAt(0);
-  		var compA = typeof o[a] === 'object' ? 1 : -1;
-  		var compB = typeof o[b] === 'object' ? 1 : -1;
-  		if (compA - compB !== 0) {
-    		return compA - compB;
-  		}
-  		compA = a0 === '$' || a0 === '#' ? 1 : -1;
-  		compB = b0 === '$' || b0 === '#' ? 1 : -1;
-  		return compA - compB;
+			var a0 = a.charAt(0);
+			var b0 = b.charAt(0);
+			var compA = typeof o[a] === 'object' ? 1 : -1;
+			var compB = typeof o[b] === 'object' ? 1 : -1;
+			if (compA - compB !== 0) {
+				return compA - compB;
+			}
+			compA = a0 === '$' || a0 === '#' ? 1 : -1;
+			compB = b0 === '$' || b0 === '#' ? 1 : -1;
+			return compA - compB;
 		}
 		keys.sort(keyComparator);
 		return keys;

--- a/test/toxml.js
+++ b/test/toxml.js
@@ -141,25 +141,25 @@ exports['t06'] = function (test) {
 	test.done();
 };
 exports['t07'] = function (test) {
-  input = {
-    key: {
-      $t: "value",
-      arg: "arg"
-    }
-  };
-  test.equal(XMLMapping.dump(input), '<key arg="arg">value</key>');
+	input = {
+		key: {
+			$t: "value",
+			arg: "arg"
+		}
+	};
+	test.equal(XMLMapping.dump(input), '<key arg="arg">value</key>');
 	test.done();
 };
 exports['t08'] = function (test) {
-  input = {
-    key: {
-      a: "a",
-      val: {
-        $t: "val"
-      },
-      c: "c"
-    }
-  };
-  test.equal(XMLMapping.dump(input), '<key a="a" c="c"><val>val</val></key>');
+	input = {
+		key: {
+			a: "a",
+			val: {
+				$t: "val"
+			},
+			c: "c"
+		}
+	};
+	test.equal(XMLMapping.dump(input), '<key a="a" c="c"><val>val</val></key>');
 	test.done();
 };


### PR DESCRIPTION
This pull request addresses the following problems:
- _ is a valid character that the attribute names can start with (http://www.xml.com/axml/target.html#NT-Name) and thus it is not desirable to treat it as a special case (like text, comment or cdata with # and $). I removed that case from parse implementation and made sure that the tests are updated.
- Fixed a bug where special field (text, comment, cdata) is found before all the attributes are handled and consequently improperly parsed (test case 7).
- Fixed a bug where a nesting is found before all the attributes are handled and consequently improperly parsed (test case 8).
