### PR TITLE
Passing options.indent along when creating XmlWriter

### DIFF
--- a/lib/xml-mapping.js
+++ b/lib/xml-mapping.js
@@ -6,7 +6,7 @@ exports.dump = function(obj, options) {
 
 	if (typeof obj != "object") return obj;
 	//    if (typeof xw != XMLWriter) 
-	var	xw = new XMLWriter();
+	var	xw = new XMLWriter(options.indent);
 
 
 	var getype = function(o) {

--- a/test/toxml.js
+++ b/test/toxml.js
@@ -163,3 +163,16 @@ exports['t08'] = function (test) {
 	test.equal(XMLMapping.dump(input), '<key a="a" c="c"><val>val</val></key>');
 	test.done();
 };
+exports['t09'] = function (test) {
+	input = {
+		key: {
+			a: "a",
+			val: {
+				$t: "val"
+			},
+			c: "c"
+		}
+	};
+	test.equal(XMLMapping.dump(input, { indent: true }), '<key a="a" c="c">\n    <val>val</val>\n</key>');
+	test.done();
+};


### PR DESCRIPTION
At this point options are entirely ignored in `dump`.
XmlWriter has an indent param however, so we can use options to pass this configuration along.
