### PR TITLE
Added header option with optional version and encoding

### DIFF
--- a/lib/xml-mapping.js
+++ b/lib/xml-mapping.js
@@ -10,7 +10,9 @@ exports.dump = function (obj, options) {
   }
   //    if (typeof xw != XMLWriter) 
   var	xw = new XMLWriter(options.indent);
-
+  if (options.header) {
+    xw.startDocument(options.version || '1.0', options.encoding || 'utf-8');
+  }
 
   var getype = function (o) {
     if (!o) {


### PR DESCRIPTION
XMLWriter can write a header (e.g. `<?xml version="1.0" encoding="utf-8"?>`) to its output, but xml-mapping provides no way to use this. This change enables it if header is set true in options. It also adds version (default 1.0) and encoding (default utf-8) options.
