### PR TITLE
Stop top level comments from triggering root element wrapping

### DIFF
--- a/lib/xml-mapping.js
+++ b/lib/xml-mapping.js
@@ -144,8 +144,20 @@ exports.dump = function (obj, options) {
       }
     }
   }
+  var countRoots = function (o) {
+    var count = 0;
+    for (var key in o) {
+      if (o.hasOwnProperty(key)) {
+        // if (0 !== prop.indexOf(options.specialChar)) {
+        if (key !== options.specialChar + commentLongTag && key !== options.specialChar + commentShortTag && key != '#comment') {
+          count++;
+        }
+      }
+    }
+    return count;
+  }
   var o = {};
-  if (Object.keys(obj).length == 1) {
+  if (countRoots(obj) == 1) {
     o = obj;
   }
   else {

--- a/test/toxml.js
+++ b/test/toxml.js
@@ -3,15 +3,15 @@ var input;
 
 exports['t00'] = function (test) {
 	input = {};
-	test.equal(XMLMapping.dump(input), '<row/>') 
+	test.equal(XMLMapping.dump(input), '<row/>')
 	input = 'string';
-	test.equal(XMLMapping.dump(input), 'string') 
+	test.equal(XMLMapping.dump(input), 'string')
 	input = 1234;
-	test.equal(XMLMapping.dump(input), 1234) 
+	test.equal(XMLMapping.dump(input), 1234)
 	test.done();
 };
 exports['t01'] = function (test) {
-	input = { 
+	input = {
 		key : {}
 	};
 	test.equal(XMLMapping.dump(input), '<key/>');
@@ -31,11 +31,11 @@ exports['t01'] = function (test) {
 	test.done();
 };
 exports['t02'] = function (test) {
-	input = { 
+	input = {
 		key1 : {},
 		key2 : {}
 	};
-	test.equal(XMLMapping.dump(input), '<row><key1/><key2/></row>'); 
+	test.equal(XMLMapping.dump(input), '<row><key1/><key2/></row>');
 	input = {
 		key1 : {
 			key: 'value'
@@ -44,7 +44,7 @@ exports['t02'] = function (test) {
 			key: 'value'
 		}
 	};
-	test.equal(XMLMapping.dump(input), '<row><key1 key="value"/><key2 key="value"/></row>'); 
+	test.equal(XMLMapping.dump(input), '<row><key1 key="value"/><key2 key="value"/></row>');
 	input = {
 		key1 : {
 			keyA: 'value1',
@@ -62,14 +62,14 @@ exports['t03a'] = function (test) {
 	input = {
 		key : []
 	};
-	test.equal(XMLMapping.dump(input), '<key/>'); 
+	test.equal(XMLMapping.dump(input), '<key/>');
 	test.done();
 }
 exports['t03b'] = function (test) {
 	input = {
 		key : [{},{}]
 	};
-	test.equal(XMLMapping.dump(input), '<key/><key/>'); 
+	test.equal(XMLMapping.dump(input), '<key/><key/>');
 	test.done();
 }
 exports['t03c'] = function (test) {
@@ -113,7 +113,7 @@ exports['t05a'] = function (test) {
 	input = {
 		'#element' : [{ $cd : 'value'}, { '#cd' : 'value'}]
 	};
-	test.equal(XMLMapping.dump(input), '<![CDATA[value]]><![CDATA[value]]>'); 
+	test.equal(XMLMapping.dump(input), '<![CDATA[value]]><![CDATA[value]]>');
 	test.done();
 };
 exports['t05b'] = function (test) {
@@ -122,7 +122,7 @@ exports['t05b'] = function (test) {
 			'#element' : [{ $t : 'amstra'}, { _t : 'mdram'}]
 		}
 	};
-	test.equal(XMLMapping.dump(input), '<key>amstramdram</key>'); 
+	test.equal(XMLMapping.dump(input), '<key>amstramdram</key>');
 	test.done();
 };
 exports['t06'] = function (test) {
@@ -131,13 +131,13 @@ exports['t06'] = function (test) {
 			'$t' : 1
 		}
 	};
-	test.equal(XMLMapping.dump(input), '<key>1</key>'); 
+	test.equal(XMLMapping.dump(input), '<key>1</key>');
 		input = {
 		key : {
 			'$t' : 0
 		}
 	};
-	test.equal(XMLMapping.dump(input), '<key>0</key>'); 
+	test.equal(XMLMapping.dump(input), '<key>0</key>');
 	test.done();
 };
 exports['t07'] = function (test) {
@@ -176,3 +176,35 @@ exports['t09'] = function (test) {
 	test.equal(XMLMapping.dump(input, { indent: true }), '<key a="a" c="c">\n    <val>val</val>\n</key>');
 	test.done();
 };
+exports['t10a'] = function (test) {
+	input = {
+		'$c' : ' comment ',
+		key1 : {
+			key2 : {
+				'$cd' : 'value1'
+			},
+			key3 : {
+				'$t' : 'value2'
+			}
+		}
+	};
+  output = '<!-- comment --><key1><key2><![CDATA[value1]]></key2><key3>value2</key3></key1>';
+  test.equal(XMLMapping.dump(input), output);
+	test.done();
+}
+exports['t10b'] = function (test) {
+	input = {
+		'$c' : ' comment ',
+		key1 : {
+			key2 : {
+				'$cd' : 'value1'
+			},
+			key3 : {
+				'$t' : 'value2'
+			}
+		}
+	};
+  output = '<?xml version="1.0" encoding="UTF-8"?>\n<!-- comment -->\n<key1>\n    <key2>\n    <![CDATA[value1]]></key2>\n    <key3>value2</key3>\n</key1>';
+  test.equal(XMLMapping.dump(input, {header:true, version: '1.0', encoding:'UTF-8', indent: true}), output);
+	test.done();
+}


### PR DESCRIPTION
Added a little extra checking and a couple tests.
